### PR TITLE
Always quantize global average pool

### DIFF
--- a/README_EPU.md
+++ b/README_EPU.md
@@ -1,0 +1,23 @@
+# The Quadric Version of onnxruntime
+
+This repository contains the a distribution of onnxruntime with additional operator quantization capabilities.
+
+
+## Prerequisites:
+- python 3.9
+- pip
+
+## Clone repository and build:
+```
+git clone --recursive https://github.com/quadric-io/onnxruntime onnxruntime
+cd onnxruntime
+# Install wheel
+pip install wheel
+# Build the python package
+./build.sh --build_wheel --config Release --parallel
+```
+
+## Install 
+```
+pip install build/MacOS/Release/dist/onnxruntime-1.14.0-cp39-cp39-macosx_11_0_x86_64.whl
+```

--- a/onnxruntime/python/tools/quantization/operators/gavgpool.py
+++ b/onnxruntime/python/tools/quantization/operators/gavgpool.py
@@ -11,10 +11,15 @@ class QGlobalAveragePool(QuantOperatorBase):
     def quantize(self):
         node = self.node
         assert node.op_type == "GlobalAveragePool"
-
-        # If input to this node is not quantized then keep this node.
+        nodes = []
+        # If input to this node is not quantized then force the quantization.
         if node.input[0] not in self.quantizer.quantized_value_map:
-            return super().quantize()
+            (
+                quantized_input_names,
+                zero_point_names,
+                scale_names,
+                nodes,
+            ) = self.quantizer.quantize_activation(node, [0])
 
         quantized_input_value = self.quantizer.quantized_value_map[node.input[0]]
 
@@ -59,4 +64,5 @@ class QGlobalAveragePool(QuantOperatorBase):
             qnode_name,
             **kwargs,
         )
-        self.quantizer.new_nodes += [qnode]
+        nodes.append(qnode)
+        self.quantizer.new_nodes += nodes

--- a/onnxruntime/python/tools/quantization/registry.py
+++ b/onnxruntime/python/tools/quantization/registry.py
@@ -51,6 +51,7 @@ QLinearOpsRegistry = {
     "Split": QSplit,
     "Pad": QPad,
     "Reshape": Direct8BitOp,
+    "Flatten": Direct8BitOp,
     "Squeeze": Direct8BitOp,
     "Unsqueeze": Direct8BitOp,
     "Resize": QResize,

--- a/onnxruntime/test/python/quantization/test_op_gavgpool.py
+++ b/onnxruntime/test/python/quantization/test_op_gavgpool.py
@@ -104,10 +104,10 @@ class TestOpGlobalAveragePool(unittest.TestCase):
 
         quant_nodes = {
             "QLinearConv": 1,
-            "GlobalAveragePool": 1,
-            "QLinearGlobalAveragePool": 1,
-            "QuantizeLinear": 1,
-            "DequantizeLinear": 1,
+            "GlobalAveragePool": 0,
+            "QLinearGlobalAveragePool": 2,
+            "QuantizeLinear": 2,
+            "DequantizeLinear": 2,
         }
         check_op_type_count(self, model_q8_path, **quant_nodes)
         qnode_io_qtypes = {


### PR DESCRIPTION
### Description
Enable the quantization of global average pool operators in all situations, by adding a `QuantizeLinear` node before if the input is not quantized. 


### Motivation and Context
Because EPU only supports quantized `GAP`, in the case of symmetric quantization and `ReLU + GAP` patterns we need to still perform `GAP` quantization, even if the input in not quantized. To achieve this add an input quantization node if the GAP handler if required.
Treat `Flatten` as a transparent node for quantization, the same way `Reshape` is handled.
Updates tests and adds install `README`.

