### PR TITLE
Shape inference for QLinearConvTranspose

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -213,6 +213,7 @@ class SymbolicShapeInference:
             "QLinearAdd": self._infer_qlinear_binary_op,
             "QLinearMul": self._infer_qlinear_binary_op,
             "QLinearLeakyRelu": self._infer_qlinear_unary_op,
+            "QLinearConvTranspose": self._infer_qlinear_binary_op,
             "QLinearSigmoid": self._infer_qlinear_unary_op,
             "QLinearSoftmax": self._infer_qlinear_unary_op,
             "QLinearGlobalAveragePool": self._infer_qlinear_unary_op,

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -924,6 +924,8 @@ class SymbolicShapeInference:
         # For qlinear binary operators the input order is
         # [inp_0, inp_0_scale, inp_0_zp, inp_1, inp_1_scale, inp_1_zp, out_scale, out_zp]
         # and we want to preserve [inp_0, inp_1]
+        # This also applies to operators where the shape is determined by the input and weight shapes, such as
+        # QLinearConv and QLinearConvTranspose
         # https://github.com/quadric-io/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.QLinearAdd
         prequant_input_idx = [0, 3]
         self._qlinear_onnx_shape_infer(node, prequant_input_idx)

--- a/onnxruntime/test/python/quantization/test_quant_shape_inference.py
+++ b/onnxruntime/test/python/quantization/test_quant_shape_inference.py
@@ -325,6 +325,46 @@ class TestQLinearOpsShapeInfer(unittest.TestCase):
                          [1, 32],
                          "Wrong shape inferred for quantized network output")
 
+    def test_shape_qlinear_conv_transpose(self):
+        model = self.get_model(
+            helper.make_node(
+                "QLinearConvTranspose",
+                inputs=[
+                    "input",
+                    "input_scale",
+                    "input_zero_point",
+                    "conv_transpose_wt_quantized",
+                    "weight_scale",
+                    "weight_zero_point",
+                    "conv_transpose_out_scale",
+                    "conv_transpose_out_zero_point",
+                    "conv_transpose_bias"
+                ],
+                outputs=["output"],
+                name="quant_node",
+                domain="com.microsoft",
+                auto_pad=b'NOTSET',
+                dilations=[1, 1],
+                group=1,
+                kernel_shape=[2, 2],
+                pads=[0, 0, 0, 0],
+                strides=[2, 2]
+            ),
+            [1, 32, 14, 14],
+            [
+                numpy_helper.from_array(np.array(0.007874015718698502, dtype="float32"), name="input_scale"),
+                numpy_helper.from_array(np.array(0, dtype="int8"), name="input_zero_point"),
+                numpy_helper.from_array(np.ones([32, 64, 2, 2]).astype("int8"), name="conv_transpose_wt_quantized"),
+                numpy_helper.from_array(np.array(0.007874015718698502, dtype="float32"), name="weight_scale"),
+                numpy_helper.from_array(np.array(0, dtype="int8"), name="weight_zero_point"),
+                numpy_helper.from_array(np.array(0.007874015718698502, dtype="float32"), name="conv_transpose_out_scale"),
+                numpy_helper.from_array(np.array(0, dtype="int8"), name="conv_transpose_out_zero_point"),
+                numpy_helper.from_array(np.ones([64]).astype("int32"), name="conv_transpose_bias"),
+            ]
+        )
+        self.assertEqual(self.infer_out_shape(model),
+                         [1, 64, 28, 28],
+                         "Wrong shape inferred for quantized network output")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description
Registers a shape inference handler for the `QLinearConvTranspose` operator. Because the output shape is determined by the input and weight shape combined with the operator attributes we can reuse the `_infer_qlinear_binary_op` to create a proxy `ConvTranspose` node with the same tensor shapes and attributes and use ONNX inference on it to determine the output shape.

### Motivation and Context
Shape inference for `QLinearConvTranspose` is required for lowering networks such as UNet and Centernet which use the operator.


