### PR TITLE
QuadricCustomOp: Handle multiple outputs when shape inferencing

### DIFF
--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -2930,7 +2930,6 @@ This op functions in much the same was as Dropout-11 and Dropout-13 do, execpt t
       .Attr("element_wise", "True (1) if only element-wise ops, False (0) otherwise", AttributeProto::INT, true)
       .TypeConstraint("T", OpSchema::all_tensor_types_with_bfloat(),
                       "Allow inputs and outputs to be any kind of tensor.");
-  // FIXME: Add a type/shape inference function
 
 #ifdef ENABLE_TRAINING_OPS
   // Should remove the shrunken_gather include from ENABLE_TRAINING_OPS once 1). compute optimizer is enabled for inference or


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Changes symbolic shape inferencing for `QuadricCustomOp` to handle multiple outputs


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Symbolic shape inferencing for `QuadricCustomOp` assumed a single output


