### PR TITLE
fix Quadric CustomOp domain during quantization

### DIFF
--- a/onnxruntime/python/tools/quantization/onnx_model.py
+++ b/onnxruntime/python/tools/quantization/onnx_model.py
@@ -51,7 +51,7 @@ def _clean_initializers_helper(graph, model):
                 else:
                     new_attribute = attribute_to_kwarg(attr)
                 kwargs.update(new_attribute)
-            new_node = onnx_helper.make_node(node.op_type, node.input, node.output, name=node.name, **kwargs)
+            new_node = onnx_helper.make_node(node.op_type, node.input, node.output, name=node.name, domain=node.domain, **kwargs)
         new_nodes.append(new_node)
 
     graph.ClearField("node")


### PR DESCRIPTION
This patch fixes the following issue:

If the input model has QuadricCustomOp nodes, the quantization process preserves them as is. However, the domain `com.quadric` is not preserved during this process. QuadricCustomOp's in the quantized model end up having the default domain assigned to them.

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


