### PR TITLE
Shape inference for opset 18 ReduceMean

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -167,6 +167,7 @@ class SymbolicShapeInference:
             "Reciprocal": self._pass_on_shape_and_type,
             "ReduceSum": self._infer_ReduceSum,
             "ReduceProd": self._infer_ReduceProd,
+            "ReduceMean": self._infer_ReduceMean,
             "Reshape": self._infer_Reshape,
             "Resize": self._infer_Resize,
             "Round": self._pass_on_shape_and_type,
@@ -1625,6 +1626,41 @@ class SymbolicShapeInference:
             data = self._get_int_or_float_values(node)[0]
             if data is not None:
                 self.sympy_data_[node.output[0]] = sympy_reduce_product(data)
+
+    def _infer_ReduceMean(self, node):
+        keep_dims = get_attribute(node, "keepdims", 1)
+        if get_opset(self.out_mp_) >= 18 and len(node.input) > 1:
+            # ReduceMean changes axes to input[1] in opset 18
+            axes = self._try_get_value(node, 1)
+            vi = self.known_vi_[node.output[0]]
+            if axes is None:
+                assert keep_dims  # can only handle keep_dims==True when axes is unknown, by generating new ranks
+                vi.CopyFrom(
+                    helper.make_tensor_value_info(
+                        node.output[0],
+                        self.known_vi_[node.input[0]].type.tensor_type.elem_type,
+                        get_shape_from_sympy_shape(self._new_symbolic_shape(self._get_shape_rank(node, 0), node)),
+                    )
+                )
+            else:
+                shape = self._get_shape(node, 0)
+                output_shape = []
+                axes = [handle_negative_axis(a, len(shape)) for a in axes]
+                for i, d in enumerate(shape):
+                    if i in axes:
+                        if keep_dims:
+                            output_shape.append(1)
+                    else:
+                        output_shape.append(d)
+                vi.CopyFrom(
+                    helper.make_tensor_value_info(
+                        node.output[0],
+                        self.known_vi_[node.input[0]].type.tensor_type.elem_type,
+                        output_shape,
+                    )
+                )
+
+
 
     def _infer_RelativePositionBias(self, node):  # noqa: N802
         seq_len = self._try_get_value(node, 1)

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1590,34 +1590,7 @@ class SymbolicShapeInference:
         keep_dims = get_attribute(node, "keepdims", 1)
         if get_opset(self.out_mp_) >= 13 and len(node.input) > 1:
             # ReduceSum changes axes to input[1] in opset 13
-            axes = self._try_get_value(node, 1)
-            vi = self.known_vi_[node.output[0]]
-            if axes is None:
-                assert keep_dims  # can only handle keep_dims==True when axes is unknown, by generating new ranks
-                vi.CopyFrom(
-                    helper.make_tensor_value_info(
-                        node.output[0],
-                        self.known_vi_[node.input[0]].type.tensor_type.elem_type,
-                        get_shape_from_sympy_shape(self._new_symbolic_shape(self._get_shape_rank(node, 0), node)),
-                    )
-                )
-            else:
-                shape = self._get_shape(node, 0)
-                output_shape = []
-                axes = [handle_negative_axis(a, len(shape)) for a in axes]
-                for i, d in enumerate(shape):
-                    if i in axes:
-                        if keep_dims:
-                            output_shape.append(1)
-                    else:
-                        output_shape.append(d)
-                vi.CopyFrom(
-                    helper.make_tensor_value_info(
-                        node.output[0],
-                        self.known_vi_[node.input[0]].type.tensor_type.elem_type,
-                        output_shape,
-                    )
-                )
+            self._infer_reduce_common(node)
 
     def _infer_ReduceProd(self, node):  # noqa: N802
         axes = get_attribute(node, "axes")
@@ -1631,36 +1604,37 @@ class SymbolicShapeInference:
         keep_dims = get_attribute(node, "keepdims", 1)
         if get_opset(self.out_mp_) >= 18 and len(node.input) > 1:
             # ReduceMean changes axes to input[1] in opset 18
-            axes = self._try_get_value(node, 1)
-            vi = self.known_vi_[node.output[0]]
-            if axes is None:
-                assert keep_dims  # can only handle keep_dims==True when axes is unknown, by generating new ranks
-                vi.CopyFrom(
-                    helper.make_tensor_value_info(
-                        node.output[0],
-                        self.known_vi_[node.input[0]].type.tensor_type.elem_type,
-                        get_shape_from_sympy_shape(self._new_symbolic_shape(self._get_shape_rank(node, 0), node)),
-                    )
-                )
-            else:
-                shape = self._get_shape(node, 0)
-                output_shape = []
-                axes = [handle_negative_axis(a, len(shape)) for a in axes]
-                for i, d in enumerate(shape):
-                    if i in axes:
-                        if keep_dims:
-                            output_shape.append(1)
-                    else:
-                        output_shape.append(d)
-                vi.CopyFrom(
-                    helper.make_tensor_value_info(
-                        node.output[0],
-                        self.known_vi_[node.input[0]].type.tensor_type.elem_type,
-                        output_shape,
-                    )
-                )
+            self._infer_reduce_common(node)
 
-
+    def _infer_reduce_common(self, node):
+        axes = self._try_get_value(node, 1)
+        vi = self.known_vi_[node.output[0]]
+        if axes is None:
+            assert keep_dims  # can only handle keep_dims==True when axes is unknown, by generating new ranks
+            vi.CopyFrom(
+                helper.make_tensor_value_info(
+                    node.output[0],
+                    self.known_vi_[node.input[0]].type.tensor_type.elem_type,
+                    get_shape_from_sympy_shape(self._new_symbolic_shape(self._get_shape_rank(node, 0), node)),
+                )
+            )
+        else:
+            shape = self._get_shape(node, 0)
+            output_shape = []
+            axes = [handle_negative_axis(a, len(shape)) for a in axes]
+            for i, d in enumerate(shape):
+                if i in axes:
+                    if keep_dims:
+                        output_shape.append(1)
+                else:
+                    output_shape.append(d)
+            vi.CopyFrom(
+                helper.make_tensor_value_info(
+                    node.output[0],
+                    self.known_vi_[node.input[0]].type.tensor_type.elem_type,
+                    output_shape,
+                )
+            )
 
     def _infer_RelativePositionBias(self, node):  # noqa: N802
         seq_len = self._try_get_value(node, 1)


### PR DESCRIPTION
This PR is for adding the necessary shape inferencing logic for Opset 18 `ReduceMean`. This not being present prevented PyTorch exported EfficientNet to be compatible with `graphutils`, as `GlobalAveragePool` is run with `ReduceMean` under the hood in PyTorch.