### PR TITLE
Added write permission for wheel.yaml

### DIFF
--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -63,6 +63,8 @@ jobs:
         path: ${{ env.wheel_path }}
 
   create_release:
+    permissions:
+      contents: write
     if: (github.ref == 'refs/heads/main') && ( github.event_name != 'workflow_call' && github.event_name != 'workflow_dispatch' )
     needs: [build_and_upload_wheel_mac, build_and_upload_wheel_linux]
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds [write permissions](https://github.com/softprops/action-gh-release/issues/236#issuecomment-1150530128) to fix the `create_release` workflow failures.