### PR TITLE
Disabling type check in GAP test due to fixing onnx version

### DIFF
--- a/onnxruntime/test/python/quantization/test_op_gavgpool.py
+++ b/onnxruntime/test/python/quantization/test_op_gavgpool.py
@@ -112,7 +112,15 @@ class TestOpGlobalAveragePool(unittest.TestCase):
         qnode_io_qtypes = {
             "QuantizeLinear": [
                 ["i", 2, activation_proto_qtype],
-                ["o", 0, activation_proto_qtype],
+                # TODO: The check on the output edge of QuantizeLinear is commented out since the required version of
+                # onnx==1.16 fails to provide value information after shape inference from the call
+                # model = onnx.shape_inference.infer_shapes(model) within the upcoming function
+                # check_qtype_by_node_type. This eventually leads to an assert error since this information is needed
+                # to check expected types. This is resolved in onnx==1.17. However, the current version of onnxruntime
+                # has limited support for onnx==1.17 and its default opset. Once we perform the next rebase on public ORT,
+                # we should uncomment if onnxruntime supports 1.17+ and the assert failure is confirmed to be resolved
+                # at that time.
+                # ["o", 0, activation_proto_qtype],
             ]
         }
         qnode_io_qtypes.update(


### PR DESCRIPTION
Needed for ort v23 and upgraded onnx==1.16 compatibility.

See details here: https://github.com/quadric-io/tvm/issues/1816

Created an issue to follow up on during next rebase: https://github.com/quadric-io/onnxruntime/issues/30

Closes https://github.com/quadric-io/tvm/issues/1816