### PR TITLE
Fixing implicit cast from double to single float

### DIFF
--- a/onnxruntime/core/mlas/lib/quantize.cpp
+++ b/onnxruntime/core/mlas/lib/quantize.cpp
@@ -120,8 +120,9 @@ int deriveFractionalBits(float scalar, int qfpSize) {
 }
 
 // Function to convert scalar to qfp
+template <typename T>
 int
-scalarToQfp(float value, int fracBits)
+scalarToQfp(T value, int fracBits)
 {
     double mult = static_cast<double>(1ULL << fracBits);
     int qfp = static_cast<int>(static_cast<double>(value) * mult);

--- a/onnxruntime/test/contrib_ops/quantize_linear_fixed_point_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_linear_fixed_point_test.cc
@@ -29,5 +29,15 @@ TEST(QuantizeLinearFixedPointTest, FourDimTest) {
   tester.Run();
 }
 
+TEST(QuantizeLinearFixedPointTest, ExactMidpointBeforeRound) {
+  OpTester tester("QuantizeLinearFixedPoint", 1, kQuadricDomain);
+  tester.AddInput<int32_t>("X", {1}, {116449696});
+  tester.AddInput<int8_t>("x_frac_bits", {}, {27});
+  tester.AddInput<float>("scale", {}, {0x1.31b3340000000p-6f});
+  tester.AddInput<int8_t>("zero_point", {}, {-14});
+  tester.AddOutput<int8_t>("Y", {1}, {33});
+  tester.Run();
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
Introduced templated version scalarToQfp. Original was defined only for single float input and thus this caused a double to be implicitly cast to single. This introduced enough numerical error to differ from CGC output for the case where the round was right around x.5 within quantizeLinearFixedPoint.

I also added test for this particular edge case
