### PR TITLE
qlinear conv fix and update to sessionOptions

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -289,3 +289,6 @@ static const char* const kOrtSessionOptionsQDQMatMulNBitsAccuracyLevel = "sessio
 // “Default”: OS determines the scheduling priority and processor performance to service this workload. [Default]
 // “Efficient”: OS treats this workload is efficiency oriented with low scheduling priority and efficient processor performance.
 static const char* const kOrtEpDynamicOptionsWorkloadType = "ep.dynamic.workload_type";
+
+// GPNPU mode
+static const char* const kOrtSessionOptionsGpnpuMode = "session.enable_gpnpu";

--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_binary_op.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_binary_op.cc
@@ -6,7 +6,6 @@
 #include "core/providers/common.h"
 #include "core/mlas/inc/mlas.h"
 #include "core/platform/threadpool.h"
-#include "core/framework/op_kernel_context_internal.h"
 
 using onnxruntime::concurrency::ThreadPool;
 
@@ -96,15 +95,8 @@ void QLinearImpl(OpKernelContext& context, double unit_cost, const ProcessBroadc
 
 template <typename T>
 Status QLinearAdd<T>::Compute(OpKernelContext* context) const {
-  auto* internal_context = dynamic_cast<OpKernelContextInternal*>(context);
-  if (!internal_context) {
-      return Status(common::ONNXRUNTIME, common::FAIL, "Failed to cast OpKernelContext to OpKernelContextInternal");
-  }
-  const auto& session_options = internal_context->GetSessionState().GetSessionOptions();
 
-  const bool gpnpu_flag = session_options.enable_gpnpu;
-
-  const ProcessBroadcastSpanFuncs functors = gpnpu_flag ? ProcessBroadcastSpanFuncs{
+  const ProcessBroadcastSpanFuncs functors = gpnpu_flag_ ? ProcessBroadcastSpanFuncs{
         [](BroadcastHelper& per_iter_bh) {
             QLinearBroadcastHelper& qlbh = static_cast<QLinearBroadcastHelper&>(per_iter_bh);
             const T input0 = per_iter_bh.ScalarInput0<T>();

--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_binary_op.h
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_binary_op.h
@@ -15,8 +15,7 @@ template <typename T>
 class QLinearAdd final : public OpKernel {
  public:
   QLinearAdd(const OpKernelInfo& info) : OpKernel(info) {
-    auto gpnpu_flag_str = info.GetConfigOptions().GetConfigOrDefault(kOrtSessionOptionsGpnpuMode, "0");
-    gpnpu_flag_ = (gpnpu_flag_str == "1");
+  gpnpu_flag_ = (info.GetConfigOptions().GetConfigOrDefault(kOrtSessionOptionsGpnpuMode, "0") == "1");
   }
 
   Status Compute(OpKernelContext* context) const override;

--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_binary_op.h
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_binary_op.h
@@ -6,6 +6,7 @@
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
 #include "core/util/math_cpuonly.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 
 namespace onnxruntime {
 namespace contrib {
@@ -13,9 +14,15 @@ namespace contrib {
 template <typename T>
 class QLinearAdd final : public OpKernel {
  public:
-  QLinearAdd(const OpKernelInfo& info) : OpKernel(info) {}
+  QLinearAdd(const OpKernelInfo& info) : OpKernel(info) {
+    auto gpnpu_flag_str = info.GetConfigOptions().GetConfigOrDefault(kOrtSessionOptionsGpnpuMode, "0");
+    gpnpu_flag_ = (gpnpu_flag_str == "1");
+  }
 
   Status Compute(OpKernelContext* context) const override;
+
+  private:
+    bool gpnpu_flag_{false};
 };
 
 template <typename T>

--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
@@ -9,7 +9,6 @@
 #include "core/util/math.h"
 #include "core/mlas/inc/mlas.h"
 #include <functional>
-#include "core/framework/op_kernel_context_internal.h"
 
 using onnxruntime::concurrency::ThreadPool;
 
@@ -130,14 +129,6 @@ Status QLinearGlobalAveragePool::Compute(OpKernelContext* context) const {
 
   auto dtype = X.GetElementType();
 
-  auto* internal_context = dynamic_cast<OpKernelContextInternal*>(context);
-  if (!internal_context) {
-      return Status(common::ONNXRUNTIME, common::FAIL, "Failed to cast OpKernelContext to OpKernelContextInternal");
-  }
-  const auto& session_options = internal_context->GetSessionState().GetSessionOptions();
-
-  const bool gpnpu_flag = session_options.enable_gpnpu;
-
   if (dtype == ONNX_NAMESPACE::TensorProto_DataType_UINT8) {
     return ComputeQLinearGlobalAvgPool(X.Data<uint8_t>(), x_scale, *(tensor_x_zero_point->Data<uint8_t>()),
                                        Y.MutableData<uint8_t>(), y_scale, *(tensor_y_zero_point->Data<uint8_t>()),
@@ -145,7 +136,7 @@ Status QLinearGlobalAveragePool::Compute(OpKernelContext* context) const {
   } else {
     return ComputeQLinearGlobalAvgPool(X.Data<int8_t>(), x_scale, *(tensor_x_zero_point->Data<int8_t>()),
                                        Y.MutableData<int8_t>(), y_scale, *(tensor_y_zero_point->Data<int8_t>()),
-                                       N, C, image_size, channels_last_, tp, gpnpu_flag);
+                                       N, C, image_size, channels_last_, tp, gpnpu_flag_);
   }
 }
 

--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.h
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.h
@@ -5,6 +5,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.h
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.h
@@ -13,12 +13,14 @@ class QLinearGlobalAveragePool final : public OpKernel {
  public:
   QLinearGlobalAveragePool(const OpKernelInfo& info) : OpKernel(info) {
     channels_last_ = (info.GetAttrOrDefault<int64_t>("channels_last", static_cast<int64_t>(0)) != 0);
+    gpnpu_flag_ = (info.GetConfigOptions().GetConfigOrDefault(kOrtSessionOptionsGpnpuMode, "0") == "1");
   }
 
   Status Compute(OpKernelContext* context) const override;
 
  private:
   bool channels_last_;
+  bool gpnpu_flag_{false};
 };
 
 template <typename T8Bits>

--- a/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
@@ -135,7 +135,7 @@ class QGemm : protected GemmBase, public MatMulIntegerBase {
   }
 
  private:
-  gpnpu_flag_{false};
+  bool gpnpu_flag_{false};
   enum InputTensors : int {
     IN_A = 0,
     IN_A_SCALE = 1,

--- a/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
@@ -10,7 +10,6 @@
 #include "core/util/math_cpuonly.h"
 #include "core/util/qmath.h"
 #include "core/mlas/inc/mlas.h"
-#include "core/framework/op_kernel_context_internal.h"
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
@@ -10,6 +10,7 @@
 #include "core/util/math_cpuonly.h"
 #include "core/util/qmath.h"
 #include "core/mlas/inc/mlas.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/core/framework/op_kernel_context_internal.h
+++ b/onnxruntime/core/framework/op_kernel_context_internal.h
@@ -42,11 +42,6 @@ class OpKernelContextInternal : public OpKernelContext {
     return session_state_.GetUseDeterministicCompute();
   }
 
-  // Add a getter method for session_state_
-  const SessionState& GetSessionState() const {
-    return session_state_;
-  }
-
   const SessionState* SubgraphSessionState(const std::string& attribute_name) {
     return session_state_.GetSubgraphSessionState(GetNodeIndex(), attribute_name);
   }

--- a/onnxruntime/core/framework/session_options.h
+++ b/onnxruntime/core/framework/session_options.h
@@ -80,9 +80,6 @@ struct SessionOptions {
   // set the execution order of the graph
   ExecutionOrder execution_order = ExecutionOrder::DEFAULT;
 
-  // set to true if emulating gpnpu
-  bool enable_gpnpu = false;
-
   // enable profiling for this session.
   bool enable_profiling = false;
 

--- a/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
@@ -522,15 +522,6 @@ Status QLinearConv<ActType>::UseSharedPrePackedBuffers(std::vector<BufferUniqueP
 
 template <typename ActType>
 Status QLinearConv<ActType>::Compute(OpKernelContext* context) const {
-  // Cast to internal type because we want to access session_options parameter
-  auto* internal_context = dynamic_cast<OpKernelContextInternal*>(context);
-  if (!internal_context) {
-      return Status(common::ONNXRUNTIME, common::FAIL, "Failed to cast OpKernelContext to OpKernelContextInternal");
-  }
-  const auto& session_options = internal_context->GetSessionState().GetSessionOptions();
-  // Test to see if we have access to enable_gpnpu flag
-  const bool gpnpu_flag = session_options.enable_gpnpu;
-
   const Tensor* X = context->Input<Tensor>(InputTensors::IN_X);
   const Tensor* W = is_W_packed_ ? nullptr : context->Input<Tensor>(InputTensors::IN_W);
   const auto& W_shape = W ? W->Shape() : W_shape_;

--- a/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
@@ -22,8 +22,8 @@ class QLinearConv : public OpKernel {
   explicit QLinearConv(const OpKernelInfo& info) : OpKernel(info), conv_attrs_(info) {
     channels_last_ = (info.GetAttrOrDefault<int64_t>("channels_last", static_cast<int64_t>(0)) != 0);
 
-    auto gpnpu_flag_str = info.GetConfigOptions().GetConfigOrDefault(kOrtSessionOptionsGpnpuMode, "0");
-    gpnpu_flag_ = (gpnpu_flag_str == "1");  }
+    gpnpu_flag_ = (info.GetConfigOptions().GetConfigOrDefault(kOrtSessionOptionsGpnpuMode, "0") == "1");
+  }
 
   Status Compute(OpKernelContext* context) const override;
 
@@ -982,7 +982,7 @@ Status QLinearConv<ActType>::Compute(OpKernelContext* context) const {
           }
         }
       }
-      if (gpnpu_flag) {
+      if (gpnpu_flag_) {
         // New MlasRequantizeOuput but for fixed point not floating point
         MlasRequantizeOutputFixedPoint(
           worker_gemm_output,

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1655,13 +1655,6 @@ void addObjectMethods(py::module& m, ExecutionProviderRegistrationFn ep_registra
           R"pbdoc(Enables the memory arena on CPU. Arena may pre-allocate memory for future usage.
 Set this option to false if you don't want it. Default is True.)pbdoc")
       .def_property(
-          "enable_gpnpu",
-          [](const PySessionOptions* options) -> bool { return options->value.enable_gpnpu; },
-          [](PySessionOptions* options, bool enable_gpnpu) -> void {
-            options->value.enable_gpnpu = enable_gpnpu;
-          },
-          R"pbdoc(Enable GPNPU mode. Default is false.)pbdoc")
-      .def_property(
           "enable_profiling",
           [](const PySessionOptions* options) -> bool { return options->value.enable_profiling; },
           [](PySessionOptions* options, bool enable_profiling) -> void {

--- a/onnxruntime/test/python/gpnpu/test_qgemm.py
+++ b/onnxruntime/test/python/gpnpu/test_qgemm.py
@@ -99,7 +99,6 @@ class TestQGemm(unittest.TestCase):
         for _ in range(num_iterations):
             # CPU Session
             session_options_cpu = ort.SessionOptions()
-            session_options_cpu.enable_gpnpu = False
             session_cpu = ort.InferenceSession(
                 self.model_path,
                 sess_options=session_options_cpu,
@@ -108,7 +107,7 @@ class TestQGemm(unittest.TestCase):
 
             # GPNPU Session
             session_options_gpnpu = ort.SessionOptions()
-            session_options_gpnpu.enable_gpnpu = True
+            session_options_gpnpu.add_session_config_entry("session.enable_gpnpu", "1")
             session_gpnpu = ort.InferenceSession(
                 self.model_path,
                 sess_options=session_options_gpnpu,

--- a/onnxruntime/test/python/gpnpu/test_qlinearadd.py
+++ b/onnxruntime/test/python/gpnpu/test_qlinearadd.py
@@ -98,7 +98,6 @@ class TestQLinearConv(unittest.TestCase):
     def test_accuracy(self):
         # CPU Session
         session_options_cpu = ort.SessionOptions()
-        session_options_cpu.enable_gpnpu = False
         session_cpu = ort.InferenceSession(
             self.model_path,
             sess_options=session_options_cpu,
@@ -107,7 +106,7 @@ class TestQLinearConv(unittest.TestCase):
 
         # GPNPU Session
         session_options_gpnpu = ort.SessionOptions()
-        session_options_gpnpu.enable_gpnpu = True
+        session_options_gpnpu.add_session_config_entry("session.enable_gpnpu", "1")
         session_gpnpu = ort.InferenceSession(
             self.model_path,
             sess_options=session_options_gpnpu,

--- a/onnxruntime/test/python/gpnpu/test_qlinearconv.py
+++ b/onnxruntime/test/python/gpnpu/test_qlinearconv.py
@@ -291,15 +291,13 @@ class TestQLinearConv(unittest.TestCase):
     def test_qlinearconv_inference(self):
         # Run inference
         session_options_gpnpu = ort.SessionOptions()
-        session_options_gpnpu.enable_gpnpu = True
+        session_options_gpnpu.add_session_config_entry("session.enable_gpnpu", "1")
 
         # Create an inference session
         session_gpnpu = ort.InferenceSession(self.model_path, sess_options=session_options_gpnpu, providers=["CPUExecutionProvider"])
         session_options_cpu = ort.SessionOptions()
         session_options_cpu.enable_gpnpu = False
         session_cpu = ort.InferenceSession(self.model_path, sess_options=session_options_cpu, providers=["CPUExecutionProvider"])
-        self.assertFalse(session_cpu.get_session_options().enable_gpnpu, "enable_gpnpu should be False for CPU session")
-        self.assertTrue(session_gpnpu.get_session_options().enable_gpnpu, "enable_gpnpu should be True for GPNPU session")
 
         # Inspect the model's input to get the name and shape
         inp_info = session_gpnpu.get_inputs()[0]

--- a/onnxruntime/test/python/gpnpu/test_qlinearconv.py
+++ b/onnxruntime/test/python/gpnpu/test_qlinearconv.py
@@ -296,7 +296,6 @@ class TestQLinearConv(unittest.TestCase):
         # Create an inference session
         session_gpnpu = ort.InferenceSession(self.model_path, sess_options=session_options_gpnpu, providers=["CPUExecutionProvider"])
         session_options_cpu = ort.SessionOptions()
-        session_options_cpu.enable_gpnpu = False
         session_cpu = ort.InferenceSession(self.model_path, sess_options=session_options_cpu, providers=["CPUExecutionProvider"])
 
         # Inspect the model's input to get the name and shape

--- a/onnxruntime/test/python/gpnpu/test_qlineargap.py
+++ b/onnxruntime/test/python/gpnpu/test_qlineargap.py
@@ -81,7 +81,6 @@ class TestQLinearGAP(unittest.TestCase):
         for _ in range(num_iterations):
             # CPU Session
             session_options_cpu = ort.SessionOptions()
-            session_options_cpu.enable_gpnpu = False
             session_cpu = ort.InferenceSession(
                 self.model_path,
                 sess_options=session_options_cpu,
@@ -90,7 +89,7 @@ class TestQLinearGAP(unittest.TestCase):
 
             # GPNPU Session
             session_options_gpnpu = ort.SessionOptions()
-            session_options_gpnpu.enable_gpnpu = True
+            session_options_gpnpu.add_session_config_entry("session.enable_gpnpu", "1")
             session_gpnpu = ort.InferenceSession(
                 self.model_path,
                 sess_options=session_options_gpnpu,


### PR DESCRIPTION
This PR has 2 main changes:

1. Need to change enable_gpnpu option from sessionOptions to configOptions. This is the more natural way to propogate this information to the kernel level after inspecting other kernels. This also gives access to this option when the kernel is initiated. 

2. Now that we can access enable_gpnpu from kernel initializer , this allows use to have knowledge off this even when we initialize the onnxruntime session. Prior we only could access this within Compute methods. This allows us to use this information at the optimization stages happening during session initialization. This let's use turn off conv symmetric optimizations that we do not currently support since this involves updating ASM code to change from floating point arithmetic to fixed point. This may come with a performance hit but decided to just exclude these optimization paths for now since the engineering effort for maintaining ASM code is potentially high. 

Overall changes eliminates optimization path that resulted in a mismatch in https://github.com/quadric-io/tvm/pull/2404 .

