### PR TITLE
Add py310 wheel

### DIFF
--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -48,7 +48,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     strategy:
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.9", "3.10", "3.14"]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -84,6 +84,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: ort-wheel-linux
+        path: artifacts/
+    - name: Download ort-wheel-mac-py3.9 artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ort-wheel-mac-py3.9
         path: artifacts/
     - name: Download ort-wheel-mac-py3.10 artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -46,6 +46,9 @@ jobs:
   build_and_upload_wheel_mac:
     if: github.repository != 'quadric-io/sdk-cli'
     runs-on: [self-hosted, macOS, ARM64]
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.14"]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -54,20 +57,20 @@ jobs:
         ref: ${{ inputs.onnxruntime_branch || github.ref }}
     - name: Setup venv and install dependencies
       run: |
-        python3.14 -m venv venv
+        python${{ matrix.python-version }} -m venv venv
         source venv/bin/activate
         python3 -m pip install setuptools wheel
         python3 -m pip install -r requirements.txt
     - name: Build ONNX Runtime wheel
       run: |
         source venv/bin/activate
-        ./build.sh --build_wheel --config Release --parallel ${{ github.event_name == 'pull_request' && ' ' || '--skip_tests'}} --skip_submodule_sync --compile_no_warning_as_error --skip_submodule_sync --apple_deploy_target 12 --cmake_extra_defines Python_EXECUTABLE=$(which python3.14)
+        ./build.sh --build_wheel --config Release --parallel ${{ github.event_name == 'pull_request' && ' ' || '--skip_tests'}} --skip_submodule_sync --compile_no_warning_as_error --skip_submodule_sync --apple_deploy_target 12 --cmake_extra_defines Python_EXECUTABLE=$(which python${{ matrix.python-version }})
         wheel_path=$(find . -name '*.whl' | xargs readlink -f)
         echo "wheel_path=$wheel_path" >> $GITHUB_ENV
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ort-wheel-mac
+        name: ort-wheel-mac-py${{ matrix.python-version }}
         path: ${{ env.wheel_path }}
 
   create_release:
@@ -82,10 +85,15 @@ jobs:
       with:
         name: ort-wheel-linux
         path: artifacts/
-    - name: Download ort-wheel-mac artifact
+    - name: Download ort-wheel-mac-py3.10 artifact
       uses: actions/download-artifact@v4
       with:
-        name: ort-wheel-mac
+        name: ort-wheel-mac-py3.10
+        path: artifacts/
+    - name: Download ort-wheel-mac-py3.14 artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ort-wheel-mac-py3.14
         path: artifacts/
     - name: Get next release tag
       id: get_tag

--- a/README_EPU.md
+++ b/README_EPU.md
@@ -4,14 +4,14 @@ This repository contains the a distribution of onnxruntime with additional opera
 
 
 ## Prerequisites:
-- python 3.9
+- python 3.9 or 3.10
 - pip
 
 ## Clone repository and build:
 ```
 git clone --recursive https://github.com/quadric-io/onnxruntime onnxruntime
 cd onnxruntime
-python3.9 -m venv venv
+python3.10 -m venv venv  # or python3.9
 source venv/bin/activate
 # some newer version of cmake may not be backward compatible.
 pip3 install cmake==3.31
@@ -33,7 +33,7 @@ pip3 install wheel packaging numpy==1.24.4
 ```
 # Find the wheel you just created
 $ find . -name '*.whl'
-./build/MacOS/Release/dist/onnxruntime-1.16.0-cp39-cp39-macosx_13_0_arm64.whl
+./build/MacOS/Release/dist/onnxruntime-1.16.0-cp310-cp310-macosx_13_0_arm64.whl
 # Install it
-pip3 install ./build/MacOS/Release/dist/onnxruntime-1.16.0-cp39-cp39-macosx_13_0_arm64.whl
+pip3 install ./build/MacOS/Release/dist/onnxruntime-1.16.0-cp310-cp310-macosx_13_0_arm64.whl
 ```


### PR DESCRIPTION
  Add Python 3.9 and 3.10 macOS wheels

  The Mac wheel job previously only built for Python 3.14. This adds a build matrix so releases include wheels for Python 3.9, 3.10, and 3.14. 3.10 has become needed in tvm to support new package versions.

  Changes
  - wheel.yaml: add strategy.matrix with python-version: ["3.9", "3.10", "3.14"]; parameterize venv creation and Python_EXECUTABLE cmake define; rename artifacts to
  ort-wheel-mac-py<version> so each version uploads independently; update create_release to download all three Mac artifacts
  - README_EPU.md: update prerequisites to reflect 3.9/3.10 support

  Testing
  CI will build and verify all three versions on the self-hosted ARM64 Mac runner on this PR.